### PR TITLE
feat: adicionar o .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,54 @@
+# ==========================================
+# Python
+# ==========================================
+# Ambientes Virtuais (venc, venv, .venv, env)
+venv/
+.venv/
+env/
+__pycache__/
+*.py[cod]
+*$py.class
+.pytest_cache/
+.coverage
+htmlcov/
+dist/
+build/
+*.egg-info/
+
+# ==========================================
+# Node.js / npm / yarn
+# ==========================================
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnp/
+.pnp.js
+dist/
+build/
+
+# ==========================================
+# Variáveis de Ambiente e Segredos
+# ==========================================
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+*.secret
+*.private
+*.key
+
+# ==========================================
+# IDEs e Editores
+# ==========================================
+.vscode/
+.idea/
+*.swp
+*.swo
+
+# ==========================================
+# Sistema Operacional
+# ==========================================
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
Adiciona o arquivo .gitignore com ambientes para python e node.

É um PR seguro e pequeno.

closes #1.